### PR TITLE
Explore serialization options and add extensibility

### DIFF
--- a/src/FluentValidation.AspNetCore.Http/FluentValidation.AspNetCore.Http.csproj
+++ b/src/FluentValidation.AspNetCore.Http/FluentValidation.AspNetCore.Http.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FluentValidation.AspNetCore.Http/FluentValidationEndpointFilterExtensions.cs
+++ b/src/FluentValidation.AspNetCore.Http/FluentValidationEndpointFilterExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using FluentValidation.AspNetCore.Http;
+using FluentValidation.AspNetCore.Http.ResultsFactory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -19,6 +21,7 @@ public static class FluentValidationEndpointFilterExtensions
             .Configure(settings => configureOptions?.Invoke(settings))
         ;
         builder.Services.AddSingleton(sp => sp.GetRequiredService<IOptions<FluentValidationEndpointFilterSettings>>().Value);
+        builder.Services.TryAddSingleton<IFluentValidationEndpointFilterResultsFactory, SimpleResultsFactory>();
         return builder;
     }
 }

--- a/src/FluentValidation.AspNetCore.Http/IFluentValidationEndpointFilterResultsFactory.cs
+++ b/src/FluentValidation.AspNetCore.Http/IFluentValidationEndpointFilterResultsFactory.cs
@@ -1,0 +1,9 @@
+﻿using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+
+namespace FluentValidation.AspNetCore.Http;
+
+public interface IFluentValidationEndpointFilterResultsFactory
+{
+    IResult Create(ValidationResult validationResult);
+}

--- a/src/FluentValidation.AspNetCore.Http/ResultsFactory/SimpleResultsFactory.cs
+++ b/src/FluentValidation.AspNetCore.Http/ResultsFactory/SimpleResultsFactory.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using HttpResults = Microsoft.AspNetCore.Http.Results;
+
+namespace FluentValidation.AspNetCore.Http.ResultsFactory;
+public class SimpleResultsFactory : IFluentValidationEndpointFilterResultsFactory
+{
+    public IResult Create(ValidationResult validationResult)
+    {
+        var errors = new Dictionary<string, string[]>();
+        var errorByProperty = validationResult.Errors.GroupBy(x => x.PropertyName);
+        foreach (var error in errorByProperty)
+        {
+            errors.Add(error.Key, error.Select(x => x.ErrorMessage).ToArray());
+        }
+        return HttpResults.ValidationProblem(errors);
+    }
+}


### PR DESCRIPTION
- Extract the `IFluentValidationEndpointFilterResultsFactory` interface
  - This allows extending the return result of the filter. The first default implementation is SimpleResultsFactory. This will be useful to change the return value from the consumer app and experiment with the filter.